### PR TITLE
support foreign keys for the given schema only

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,26 +231,20 @@ module.exports = {
 Foreign keys are specified by convention. Meaning that with the above specification, ANY property with the name
 `invoiceId` or `unitId` will be subject to a foreign key check in ALL schemas.
 
+Use dot notation if you want to apply the check for a specific schema:
+```js
+module.exports = {
+	"expense.categoryId": function(){..},
+	"income.categoryId": function(){..},
+}
+```
+
 If you want to use foreignKey checks you will have to pass `mongo` (and anything else used by your foreign key checkers) 
 in `options` when you call `validate` like this:
 
 ```js
 schemagic.invoice.validate(doc, {foreignKey:true, mongo: mongo}, callback);
 ```
-
-
-If you want specific checks that only apply to one schema, for now you have to do them elswhere.
-
-TODO: Specifying a foreign key check for one schema only could be done like this
-```js
-module.exports = {
-	"expense.categoryId": function(categoryIds, options, callback){
-		//...
-	}
-}
-```
-Where the above foreign key constraint only applies to the expense schema. THIS IS NOT IMPLEMENTED YET.
-
 
 schemagic.getSchemaFromObject() (non-enumerable)
 =====================================

--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ function schemagicInit() {
 		delete rawSchemas.foreignKeys;
 	}
 	Object.keys(rawSchemas).forEach(function (schemaName) {
-		schemagic[schemaName] = schemaFactory(rawSchemas[schemaName], foreignKeys);
+		var schemaForeignKeys = getSchemaForeignKeys(schemaName, foreignKeys);
+		schemagic[schemaName] = schemaFactory(rawSchemas[schemaName], schemaForeignKeys);
 		var rawPatchSchema = clone(rawSchemas[schemaName]);
 		var t = traverse(rawPatchSchema);
 		t.forEach(function (value) {
@@ -64,10 +65,25 @@ function schemagicInit() {
 				this.update(false);
 			}
 		});
-		schemagic[schemaName].patch = schemaFactory(rawPatchSchema, foreignKeys);
+		schemagic[schemaName].patch = schemaFactory(rawPatchSchema, schemaForeignKeys);
 	});
 	cache.schemagics[schemasDirectory] = schemagic;
 	return schemagic;
+}
+
+function getSchemaForeignKeys(schemaName, foreignKeys) {
+	return Object.keys(foreignKeys).reduce(function(memo, key) {
+		var keyParts = key.split('.');
+		if (keyParts.length ===1) {
+			memo[key] = foreignKeys[key];
+		} else {
+			var keySchemaName = keyParts.slice(0, keyParts.length-1).join('.');
+			if (keySchemaName === schemaName) {
+				memo[keyParts.pop()] = foreignKeys[key];
+			}
+		}
+		return memo;
+	}, {});	
 }
 
 module.exports = schemagicInit();

--- a/index.js
+++ b/index.js
@@ -74,10 +74,10 @@ function schemagicInit() {
 function getSchemaForeignKeys(schemaName, foreignKeys) {
 	return Object.keys(foreignKeys).reduce(function(memo, key) {
 		var keyParts = key.split('.');
-		if (keyParts.length ===1) {
+		if (keyParts.length === 1) {
 			memo[key] = foreignKeys[key];
 		} else {
-			var keySchemaName = keyParts.slice(0, keyParts.length-1).join('.');
+			var keySchemaName = keyParts.slice(0, keyParts.length - 1).join('.');
 			if (keySchemaName === schemaName) {
 				memo[keyParts.pop()] = foreignKeys[key];
 			}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "E-conomic",
   "name": "schemagic",
   "description": "JSON validation with schemas, and schema tools",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/e-conomic/schemagic"

--- a/test/integration/readRawSchemas.spec.js
+++ b/test/integration/readRawSchemas.spec.js
@@ -1,10 +1,10 @@
 var path = require('path');
 var readRawSchemas = require('../../readRawSchemas');
 
-describe('/source/util/redRawSchemas', function(){
-	describe('will read schema', function(){
+describe('/source/util/redRawSchemas', function() {
+	describe('will read schema', function() {
 		var schemas;
-		before(function(){
+		before(function() {
 			schemas = readRawSchemas(path.join(__dirname, 'schemas'));
 		});
 

--- a/test/integration/readRawSchemas.spec.js
+++ b/test/integration/readRawSchemas.spec.js
@@ -12,6 +12,7 @@ describe('/source/util/redRawSchemas', function(){
 			expect(schemas).to.eql({
 				test: require('./schemas/test'),
 				test2: require('./schemas/test2'),
+				'test3.with.dot': require('./schemas/test3.with.dot'),
 				foreignKeys: require('./schemas/foreignKeys')
 			});
 		});

--- a/test/integration/schemagic.spec.js
+++ b/test/integration/schemagic.spec.js
@@ -2,7 +2,7 @@ describe('/source/schemagic with valid example schemas', function () {
 	var schemagic;
 
 	describe('requiring schemagic here', function () {
-		before(function () {
+		before(function() {
 			schemagic = require('../../');
 		});
 
@@ -39,17 +39,17 @@ describe('/source/schemagic with valid example schemas', function () {
 			expect(schemagic).to.have.property('getSchemaFromObject').to.be.a('function');
 		});
 
-		describe('validating against test2 schema that has foreign key value, foreignKey:false - no callback', function(){
+		describe('validating against test2 schema that has foreign key value, foreignKey:false - no callback', function() {
 			var result;
 			var doc;
-			before(function(){
+			before(function() {
 				doc =  {
 					testForeignKey: 3 //this is invalid in foreign key check
 				};
 				result = schemagic.test2.validate(doc);
 			});
 
-			it('should return valid result', function(){
+			it('should return valid result', function() {
 				expect(result).to.eql({
 					"valid": true,
 					"errors": []
@@ -58,36 +58,36 @@ describe('/source/schemagic with valid example schemas', function () {
 
 		});
 
-		describe('validating against test2 schema that has foreign key value, foreignKey:true - no callback', function(){
+		describe('validating against test2 schema that has foreign key value, foreignKey:true - no callback', function() {
 			var doc, options, validate;
-			before(function(){
+			before(function() {
 				doc =  {
 					testForeignKey: 3 //this is invalid in foreign key check
 				};
 				options = {foreignKey:true};
-				validate = function(){
+				validate = function() {
 					schemagic.test2.validate(doc, options);
 				};
 			});
 
-			it('should throw an error because of no callback', function(){
+			it('should throw an error because of no callback', function() {
 				expect(validate).to['throw'];
 			});
 		});
 
-		describe('validating against test2 schema that has invalid foreign key value, foreignKey:true - callback', function(){
+		describe('validating against test2 schema that has invalid foreign key value, foreignKey:true - callback', function() {
 			var result;
 			var doc;
 			var options;
-			before(function(done){
+			before(function(done) {
 				doc =  {
 					testForeignKey: 3 //this is invalid in foreign key check
 				};
 				options = {foreignKey:true};
 				return schemagic.test2.validate(doc, options, saveResult);
 
-				function saveResult(err, res){
-					if(err){
+				function saveResult(err, res) {
+					if(err) {
 						return done(err);
 					}
 					result = res;
@@ -95,7 +95,7 @@ describe('/source/schemagic with valid example schemas', function () {
 				}
 			});
 
-			it('should return result with error', function(){
+			it('should return result with error', function() {
 				expect(result).to.eql({
 					"valid": false,
 					"errors": [{
@@ -108,9 +108,9 @@ describe('/source/schemagic with valid example schemas', function () {
 		});
 
 		describe('validating against test1 schema that has valid foreign key value, ' +
-			'foreignKey defined with dot notation and belongs to the schema, foreignKey:true - callback', function(){
+			'foreignKey defined with dot notation and belongs to the schema, foreignKey:true - callback', function() {
 			var result;
-			before(function(done){
+			before(function(done) {
 				var doc =  {
 					a: 1,
 					testForeignKey2: 12 //this is valid in 'test.testForeignKey2' foreign key check
@@ -118,8 +118,8 @@ describe('/source/schemagic with valid example schemas', function () {
 				var options = {foreignKey:true};
 				return schemagic.test.validate(doc, options, saveResult);
 
-				function saveResult(err, res){
-					if(err){
+				function saveResult(err, res) {
+					if(err) {
 						return done(err);
 					}
 					result = res;
@@ -127,7 +127,7 @@ describe('/source/schemagic with valid example schemas', function () {
 				}
 			});
 
-			it('should return result without error', function(){
+			it('should return result without error', function() {
 				expect(result).to.eql({
 					valid: true,
 					errors: []
@@ -136,17 +136,17 @@ describe('/source/schemagic with valid example schemas', function () {
 		});
 
 		describe('validating against test2 schema that has invalid foreign key value, ' +
-			'foreignKey defined with dot notation and belongs to the schema, foreignKey:true - callback', function(){
+			'foreignKey defined with dot notation and belongs to the schema, foreignKey:true - callback', function() {
 			var result;
-			before(function(done){
+			before(function(done) {
 				var doc =  {
 					testForeignKey2: 12 //this is invalid in 'test2.testForeignKey2' foreign key check
 				};
 				var options = {foreignKey:true};
 				return schemagic.test2.validate(doc, options, saveResult);
 
-				function saveResult(err, res){
-					if(err){
+				function saveResult(err, res) {
+					if(err) {
 						return done(err);
 					}
 					result = res;
@@ -154,7 +154,7 @@ describe('/source/schemagic with valid example schemas', function () {
 				}
 			});
 
-			it('should return result with error', function(){
+			it('should return result with error', function() {
 				expect(result).to.eql({
 					"valid": false,
 					"errors": [{
@@ -168,17 +168,17 @@ describe('/source/schemagic with valid example schemas', function () {
 
 		describe('validating against test3.with.dot schema that has invalid foreign key value, ' +
 			'foreignKey defined with dot notation and belongs to the schema, ' +
-			'schema has dot in its name, foreignKey:true - callback', function(){
+			'schema has dot in its name, foreignKey:true - callback', function() {
 			var result;
-			before(function(done){
+			before(function(done) {
 				var doc =  {
 					testForeignKey2: 12 //this is invalid in 'test3.with.dot.testForeignKey2' foreign key check
 				};
 				var options = {foreignKey:true};
 				return schemagic['test3.with.dot'].validate(doc, options, saveResult);
 
-				function saveResult(err, res){
-					if(err){
+				function saveResult(err, res) {
+					if(err) {
 						return done(err);
 					}
 					result = res;
@@ -186,7 +186,7 @@ describe('/source/schemagic with valid example schemas', function () {
 				}
 			});
 
-			it('should return result with error', function(){
+			it('should return result with error', function() {
 				expect(result).to.eql({
 					"valid": false,
 					"errors": [{
@@ -198,24 +198,24 @@ describe('/source/schemagic with valid example schemas', function () {
 			});
 		});
 
-		describe('validating against test2 schema with foreign key check that fails, foreignKey:true - callback', function(){
+		describe('validating against test2 schema with foreign key check that fails, foreignKey:true - callback', function() {
 			var error;
 			var doc;
 			var options;
-			before(function(done){
+			before(function(done) {
 				doc =  {
 					testForeignKeyError: 3 //this foreign key checker fails
 				};
 				options = {foreignKey:true};
 				return schemagic.test2.validate(doc, options, saveResult);
 
-				function saveResult(err){
+				function saveResult(err) {
 					error = err;
 					return done();
 				}
 			});
 
-			it('should error', function(){
+			it('should error', function() {
 				expect(error).to.be.instanceOf(Error).to.have.property('message', 'This mock foreign key check fails');
 			});
 		});
@@ -223,7 +223,7 @@ describe('/source/schemagic with valid example schemas', function () {
 
 	describe('having required schemagic in test1 dir', function () {
 		var schemagic1;
-		before(function () {
+		before(function() {
 			schemagic1 = require('./dirCacheTest/test1/requireSchemagic');
 		});
 
@@ -235,9 +235,9 @@ describe('/source/schemagic with valid example schemas', function () {
 			expect(Object.keys(schemagic1)).to.have.property('length').to.equal(1);
 		});
 
-		describe('requiring it again ()', function(){
+		describe('requiring it again ()', function() {
 			var shcmemagic2;
-			before(function(){
+			before(function() {
 				//requireSchemagic is not cached in require cache
 				shcmemagic2 = require('./dirCacheTest/test1/requireSchemagic');
 			});
@@ -250,7 +250,7 @@ describe('/source/schemagic with valid example schemas', function () {
 	});
 	describe('having required schemagic in test2 dir', function () {
 		var schemagic1;
-		before(function () {
+		before(function() {
 			schemagic1 = require('./dirCacheTest/test2/requireSchemagic');
 		});
 
@@ -262,9 +262,9 @@ describe('/source/schemagic with valid example schemas', function () {
 			expect(Object.keys(schemagic1)).to.have.property('length').to.equal(1);
 		});
 
-		describe('requiring it from subdir', function(){
+		describe('requiring it from subdir', function() {
 			var shcmemagic2;
-			before(function(){
+			before(function() {
 				shcmemagic2 = require('./dirCacheTest/test2/test2subdir/requireSchemagic');
 			});
 

--- a/test/integration/schemagic.spec.js
+++ b/test/integration/schemagic.spec.js
@@ -31,8 +31,8 @@ describe('/source/schemagic with valid example schemas', function () {
 		it('has added \'null\' in type to non-required property in \'test.patch\' schema', function () {
 			expect(schemagic.test.patch.schema).to.have.property('properties').to.have.property('c').to.have.property('type').to.contain('null');
 		});
-		it('has all the exact number og keys at there are schemas (schemagic.getSchemaFromObject is not enumerable)', function () {
-			expect(Object.keys(schemagic)).to.have.property('length').to.equal(2);
+		it('has all the exact number of keys at there are schemas (schemagic.getSchemaFromObject is not enumerable)', function () {
+			expect(Object.keys(schemagic)).to.have.property('length').to.equal(3);
 		});
 
 		it('has getSchemaFromObject as property', function () {
@@ -73,7 +73,6 @@ describe('/source/schemagic with valid example schemas', function () {
 			it('should throw an error because of no callback', function(){
 				expect(validate).to['throw'];
 			});
-
 		});
 
 		describe('validating against test2 schema that has invalid foreign key value, foreignKey:true - callback', function(){
@@ -107,6 +106,98 @@ describe('/source/schemagic with valid example schemas', function () {
 				});
 			});
 		});
+
+		describe('validating against test1 schema that has valid foreign key value, ' +
+			'foreignKey defined with dot notation and belongs to the schema, foreignKey:true - callback', function(){
+			var result;
+			before(function(done){
+				var doc =  {
+					a: 1,
+					testForeignKey2: 12 //this is valid in 'test.testForeignKey2' foreign key check
+				};
+				var options = {foreignKey:true};
+				return schemagic.test.validate(doc, options, saveResult);
+
+				function saveResult(err, res){
+					if(err){
+						return done(err);
+					}
+					result = res;
+					return done();
+				}
+			});
+
+			it('should return result without error', function(){
+				expect(result).to.eql({
+					valid: true,
+					errors: []
+				});
+			});
+		});
+
+		describe('validating against test2 schema that has invalid foreign key value, ' +
+			'foreignKey defined with dot notation and belongs to the schema, foreignKey:true - callback', function(){
+			var result;
+			before(function(done){
+				var doc =  {
+					testForeignKey2: 12 //this is invalid in 'test2.testForeignKey2' foreign key check
+				};
+				var options = {foreignKey:true};
+				return schemagic.test2.validate(doc, options, saveResult);
+
+				function saveResult(err, res){
+					if(err){
+						return done(err);
+					}
+					result = res;
+					return done();
+				}
+			});
+
+			it('should return result with error', function(){
+				expect(result).to.eql({
+					"valid": false,
+					"errors": [{
+						property: 'testForeignKey2',
+						value: 12,
+						message: 'This is not a valid value'
+					}]
+				});
+			});
+		});
+
+		describe('validating against test3.with.dot schema that has invalid foreign key value, ' +
+			'foreignKey defined with dot notation and belongs to the schema, ' +
+			'schema has dot in its name, foreignKey:true - callback', function(){
+			var result;
+			before(function(done){
+				var doc =  {
+					testForeignKey2: 12 //this is invalid in 'test3.with.dot.testForeignKey2' foreign key check
+				};
+				var options = {foreignKey:true};
+				return schemagic['test3.with.dot'].validate(doc, options, saveResult);
+
+				function saveResult(err, res){
+					if(err){
+						return done(err);
+					}
+					result = res;
+					return done();
+				}
+			});
+
+			it('should return result with error', function(){
+				expect(result).to.eql({
+					"valid": false,
+					"errors": [{
+						property: 'testForeignKey2',
+						value: 12,
+						message: 'This is not a valid value'
+					}]
+				});
+			});
+		});
+
 		describe('validating against test2 schema with foreign key check that fails, foreignKey:true - callback', function(){
 			var error;
 			var doc;

--- a/test/integration/schemas/foreignKeys.js
+++ b/test/integration/schemas/foreignKeys.js
@@ -6,5 +6,20 @@ module.exports = {
 	},
 	testForeignKeyError: function (testValues, options, callback) {
 		return callback(new Error('This mock foreign key check fails'));
+	},
+	'test1.testForeignKey2': function (testValues, options, callback) {
+		return callback(null, testValues.map(function (val) {
+			return val === 12;
+		}));
+	},
+	'test2.testForeignKey2': function (testValues, options, callback) {
+		return callback(null, testValues.map(function (val) {
+			return val === 22;
+		}));
+	},
+	'test3.with.dot.testForeignKey2': function (testValues, options, callback) {
+		return callback(null, testValues.map(function (val) {
+			return val === 32;
+		}));
 	}
 };

--- a/test/integration/schemas/test.js
+++ b/test/integration/schemas/test.js
@@ -21,6 +21,10 @@ module.exports = {
 			"type":'string',
 			"required":false,
 			"readonly":true
+		},
+		testForeignKey2:{
+			"type":'number',
+			"required":false
 		}
 	}
 };

--- a/test/integration/schemas/test2.js
+++ b/test/integration/schemas/test2.js
@@ -10,6 +10,10 @@ module.exports = {
 		testForeignKeyError:{
 			"type":'number',
 			"required":false
+		},
+		testForeignKey2:{
+			"type":'number',
+			"required":false
 		}
 	}
 };

--- a/test/integration/schemas/test3.with.dot.js
+++ b/test/integration/schemas/test3.with.dot.js
@@ -1,0 +1,10 @@
+module.exports = {
+	"required":true,
+	"type":'object',
+	"properties":{
+		testForeignKey2:{
+			"type":'number',
+			"required":false
+		}
+	}
+};


### PR DESCRIPTION
we need to support foreign keys with same name but different logic in different schemas
```
{
  'unitId': ..
  'expense.categoryId': ..
  'income.categoryId': ..
}
```